### PR TITLE
There is no need to use lodash.clonedeep

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,14 +33,12 @@
   "author": "Ola Frankowska",
   "license": "MIT",
   "peerDependencies": {
-    "lodash.clonedeep": "^4.5.9",
     "pinia": "^2.1.7"
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^15.2.3",
     "@rollup/plugin-terser": "^0.4.4",
     "@rollup/plugin-typescript": "^11.1.6",
-    "@types/lodash.clonedeep": "^4.5.9",
     "@types/node": "^20.11.24",
     "bumpp": "^9.3.1",
     "pinia": "^2.1.7",
@@ -48,7 +46,4 @@
     "tslib": "^2.6.2",
     "typescript": "^5.3.3"
   },
-  "dependencies": {
-    "lodash.clonedeep": "^4.5.0"
-  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,9 @@
-import cloneDeep from 'lodash.clonedeep'
 import type { PiniaPluginContext } from 'pinia'
 
 const piniaPluginReset = ({ store }: PiniaPluginContext) => {
-  const initialState = cloneDeep(store.$state)
+  const initialState = JSON.parse(JSON.stringify(store.$state))
   store.$reset = () => {
-    store.$patch(cloneDeep(initialState))
+    store.$patch(JSON.parse(JSON.stringify(initialState)))
   }
 }
 


### PR DESCRIPTION
# There is no need to use lodash.clonedeep
I replaced lodash.clonedeep with ```JSON.parse(JSON.stringify())``` to reduce dependencies.